### PR TITLE
Revert "chore(deps): update registry.access.redhat.com/ubi9/python-312 docker tag to v1-1731671587"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM registry.access.redhat.com/ubi9/python-312:1-1731671587
+FROM registry.access.redhat.com/ubi9/python-312:1-25.1729776548
 USER 0
 
 WORKDIR /app


### PR DESCRIPTION
Reverts GenomicDataInfrastructure/gdi-userportal-rems-synchronizer#58

## Summary by Sourcery

Chores:
- Revert the update of the Docker base image tag for registry.access.redhat.com/ubi9/python-312 to a previous version.