### PR TITLE
chore(deps): accept CVE-2024-10963 for 15 days

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2024 PNED G.I.E.
+#
+# SPDX-License-Identifier: Apache-2.0
+CVE-2024-10963 exp:2024-12-17


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Add a .trivyignore file to temporarily ignore CVE-2024-10963 for 15 days.