### PR TITLE
chore(deps): automerge patches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,14 +8,9 @@
     },
     {
       "description": "Trigger fix release for patch updates",
-      "matchPackageNames": [
-        "renovate/renovate",
-        "ghcr.io/renovatebot/renovate"
-      ],
       "automerge": true,
-      "matchUpdateTypes": ["patch"],
-      "semanticCommitType": "fix",
-      "automergeType": "pr"
+      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "automergeType": "branch"
     }
   ],
   "extends": [


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Update Renovate bot to automerge patch updates.